### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @base16-project/xfce4-terminal
+* @tinted-theming/xfce4-terminal

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,12 +13,12 @@ jobs:
         with:
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
       - name: Update schemes
-        uses: base16-project/base16-builder-go@latest
+        uses: tinted-theming/base16-builder-go@latest
       - name: Commit the changes, if any
         uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80 # v4.14.1
         with:
           commit_message: Update with the latest colorschemes
           branch: ${{ github.head_ref }}
-          commit_user_name: base16-project-bot
-          commit_user_email: base16themeproject@proton.me
-          commit_author: base16-project-bot <base16themeproject@proton.me>
+          commit_user_name: tinted-theming-bot
+          commit_user_email: tintedtheming@proton.me
+          commit_author: tinted-theming-bot <tintedtheming@proton.me>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Or the above steps represented in shell commands:
 If you have more questions about [base16-builder-go], have a look at
 the information on the GitHub page.
 
-[base16-builder-go]: https://github.com/base16-project/base16-builder-go
-[base16-schemes]: https://github.com/base16-project/base16-schemes
+[base16-builder-go]: https://github.com/tinted-theming/base16-builder-go
+[base16-schemes]: https://github.com/tinted-theming/base16-schemes
 [GitHub Action]: .github/workflows/update.yml
-[latest base16-builder-go binary]: https://github.com/base16-project/base16-builder-go/releases
+[latest base16-builder-go binary]: https://github.com/tinted-theming/base16-builder-go/releases

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Yu, Li-Yu
+Copyright (c) 2022 Tinted Theming (https://github.com/tinted-theming)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ cp -r /path/to/base16-xfce-terminal/colorschemes ~/.local/share/xfce4/terminal
 See [`CONTRIBUTING.md`], which contains building and contribution
 instructions.
 
-[base16]: https://github.com/base16-project/home
+[base16]: https://github.com/tinted-theming/home
 [xfce4-terminal]: https://docs.xfce.org/apps/terminal/start
 [`CONTRIBUTING.md`]: CONTRIBUTING.md


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

- Update references to base16-project
- Update the license
- Add scheme meta info to templates as a comment (it seems a `#` is how you add a comment in xfce4 `*.theme` files after searching online, let me know if I'm wrong)