### PR TITLE
Use shared actions for updating template and auto assignment for issues

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,0 +1,11 @@
+name: "Auto assignment for issues"
+
+on:
+  issues:
+    types: ["opened"]
+
+jobs:
+  auto-assign:
+    uses: "tinted-theming/home/.github/workflows/shared-auto-assign-issues.yml@main"
+    secrets:
+      token: ${{ secrets.BOT_ACCESS_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,24 +1,13 @@
-name: Update with the latest colorschemes
+name: Update with the latest tinted-theming colorschemes
 on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 0" # https://crontab.guru/every-week
 
 jobs:
-  run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fetch the repository code
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.BOT_ACCESS_TOKEN }}
-      - name: Update schemes
-        uses: tinted-theming/tinted-builder-rust@latest
-      - name: Commit the changes, if any
-        uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80 # v4.14.1
-        with:
-          commit_message: Update with the latest colorschemes
-          branch: ${{ github.head_ref }}
-          commit_user_name: tinted-theming-bot
-          commit_user_email: tintedtheming@proton.me
-          commit_author: tinted-theming-bot <tintedtheming@proton.me>
+  build-and-commit:
+    uses: "tinted-theming/home/.github/workflows/shared-build-template-and-commit-themes.yml@main"
+    secrets:
+      token: ${{ secrets.BOT_ACCESS_TOKEN }}
+    with:
+      ref: ${{ github.head_ref }}


### PR DESCRIPTION
1. Use a shared GitHub action to build the template and commit changes. Using a shared action helps remove boilerplate as well makes it easy to update external GitHub actions version hashes globally. Shared action: https://github.com/tinted-theming/home/blob/main/.github/workflows/shared-build-template-and-commit-themes.yml
2. Add a GitHub (shared) action which will automatically assign the team in `.github/CODEOWNERS` to newly created issues. This is surprisingly not a feature in GitHub for issues, only for PRs. Shared action: https://github.com/tinted-theming/home/blob/main/.github/workflows/shared-auto-assign-issues.yml