### PR TITLE
Move to tinted-terminal

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,8 +1,6 @@
 name: Update with the latest tinted-theming colorschemes
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 0" # https://crontab.guru/every-week
 
 jobs:
   build-and-commit:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # tinted-xfce4-terminal
 
+**Deprecation Notice**: tinted-xfce4-terminal and all the other Tinted
+Theming terminal template repositories have moved to a single [Tinted
+Terminal](https://github.com/tinted-theming/tinted-terminal) repository.
+
+---
+
 This is a [Tinted Theming] template for [xfce4-terminal].
 
 ## Installation


### PR DESCRIPTION
As discussed in https://github.com/tinted-theming/home/issues/44#issuecomment-2518520414, this PR adds a deprecation notice and links to [tinted-terminal](https://github.com/tinted-theming/tinted-terminal). You should already have maintainer access there. Once this is merged I'll archive this repo and "copy" across any issues that exist.

- Add deprecation notice to README
- Remove cron job